### PR TITLE
fix: ログインエンドポイントを/loginから/api/loginに戻す

### DIFF
--- a/breeze_next_chikaraemon/src/hooks/authFunctions.ts
+++ b/breeze_next_chikaraemon/src/hooks/authFunctions.ts
@@ -55,7 +55,7 @@ export async function performLogin(
   await axios.get('/sanctum/csrf-cookie');
 
   // ログイン処理
-  await axios.post('/login', {
+  await axios.post('/api/login', {
     email,
     password,
     remember: false,


### PR DESCRIPTION
プロジェクトガイドラインに従い、認証ルートを/api/loginに統一。
APIエンドポイントの一貫性を保ち、バックエンドのルート定義と整合性を取るため。